### PR TITLE
Clear on controlled components

### DIFF
--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -617,9 +617,7 @@ export default class Datetime extends React.Component {
 		});
 	}
 
-	_onInputClear = e => {
-		if ( !this.callHandler( this.props.inputProps.clearableInput, e ) ) return;
-
+	_onInputClear = () => {
 		let clear = {
 			inputValue: '',
 			selectedDate: undefined

--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -625,7 +625,9 @@ export default class Datetime extends React.Component {
 			selectedDate: undefined
 		};
 
-		this.setState( clear );
+		this.setState( clear, () => {
+			this.props.onChange( '' );
+		} );
 	}
 
 	_onInputKeyDown = e => {


### PR DESCRIPTION
Call onChange method when date picker is cleared, to allow use as a controlled component. 

Only setting the inputValue via setState is ignored, if the value is specified from outside as a prop.